### PR TITLE
disable built in implicit make targets

### DIFF
--- a/example-project/build.sh
+++ b/example-project/build.sh
@@ -230,12 +230,12 @@ function gexample::build::make {
         which make;\
         whoami; \
         make --version;\
-        make --file ${MAKEFILE_NAME} ${MAKE_ARGS};"
+        make --no-builtin-rules --file ${MAKEFILE_NAME} ${MAKE_ARGS};"
 }
 
 function gexample::build::container {
     gexample::build::info "Running Makefile: ${MAKEFILE_NAME} in current shell"
-    make -C ./_containerize  ${MAKE_ARGS}
+    make --no-builtin-rules -C ./_containerize  ${MAKE_ARGS}
 }
 
 

--- a/example-project/make.golang
+++ b/example-project/make.golang
@@ -1,4 +1,5 @@
-.PHONY: all biuld-all build-app repo-warning-in clean-app clean vet clean-all lint test-all view-all-coverage
+.PHONY: all build-all build-app build-darwin repo-warning-in clean-app clean doc vet clean-all lint test-all view-all-coverage
+.SUFFIXES:
 #
 # This is the Makefile to build the golang components.
 # It is normally run in a docker container for golang builds.


### PR DESCRIPTION
.SUFFIXES:   <empty> will catch most cases.
otherwise pass -r or --no-builtin-rules  to make.

fixes  make build  attempting to create build implicitly from build.sh.